### PR TITLE
cl/events: handle events using a table instead of a switch/if chain

### DIFF
--- a/cl/events.lua
+++ b/cl/events.lua
@@ -66,7 +66,6 @@ RegisterNUICallback('message', function(payload, cb)
     -- insert all params into the table in order of their name in the schema
     local params = {}
     for _, p in ipairs(schema.params) do table.insert(params, payload[p]) end
-    print(json.encode(params))
 
     -- send out the event with the unpacked params
     Events.emit(Events.global, schema.name, table.unpack(params))


### PR DESCRIPTION
Overall, this is just a better way to handle these events instead of an ever-growing if statement. Here, we can easily change the parameters passed and in what order, plus the event names. It's more ergonomic and readable (disregarding the actual handling of it).