### PR TITLE
cl/bindings: bulk send NUI messages in a thread

### DIFF
--- a/cl/bindings.lua
+++ b/cl/bindings.lua
@@ -54,21 +54,18 @@ local function shouldSend()
     local state = GetResourceState(GetCurrentResourceName())
     return state == 'started' or state == 'starting'
 end
-local function sendBulkMessages(messages)
-    -- TODO: add support for sending an array of messages instead
-    for _, m in ipairs(messages) do
-        SendNUIMessage(m)
-    end
-end
 Citizen.CreateThread(function()
     local nuiReady = false
     Events.addHandler(Events.global, 'ready', function() nuiReady = true end)
 
+    -- wait for the NUI to load
     while not nuiReady do Citizen.Wait(1) end
 
     while true do
         if #messageQueue > 0 and shouldSend() then
-            sendBulkMessages(messageQueue)
+            for _, m in ipairs(messageQueue) do
+                SendNUIMessage(m)
+            end
             messageQueue = {}
         end
         Citizen.Wait(0)

--- a/cl/stateman.lua
+++ b/cl/stateman.lua
@@ -73,9 +73,6 @@ local smEventHandlers = {
 
 -- creates a new state manager object and registers the events
 function SM.init()
-    -- wait for the UI to be ready
-    Bindings.wait()
-
     local sm = {
         id = createUid(),
 
@@ -119,20 +116,10 @@ function SM.destroy(sm)
     -- let garbage collector handle this
     SM._s[sm.id] = nil
 
-    -- for the sake of god and everything that is holy
-    -- you *need* to keep this create thread here, or else
-    -- crashes will happen
-    --
-    -- *HELP NEEDED* if you can figure out the crash, then
-    -- please fix it! It has to do with closing the menus
-    -- while you are stopping the resource, and it somehow
-    -- crashes the entire fucking client
-    Citizen.CreateThread(function()
-        -- destroy all menu objects
-        for i = 1, #sm.menus do Bindings.destroyMenu(sm.menus[i]) end
-        -- destroy all button objects
-        for i = 1, #sm.buttons do Bindings.destroyButton(sm.buttons[i]) end
-    end)
+    -- destroy all menu objects
+    for i = 1, #sm.menus do Bindings.destroyMenu(sm.menus[i]) end
+    -- destroy all button objects
+    for i = 1, #sm.buttons do Bindings.destroyButton(sm.buttons[i]) end
 end
 
 --[[ CREATION BINDINGS ]]


### PR DESCRIPTION
this will drop performance by a little but, but the advantage is that we don't need to wait for the nui to load using `Bindings.wait`.

PR also removes a chunk of code used as a workaround for the game crash when sending nui messages while resource is restarting bug, since it's now sending them in a thread instead of immediately. 